### PR TITLE
Add tests for shows fetched counter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "sweetalert2": "^11.7.27"
       },
       "devDependencies": {
+        "@babel/plugin-transform-modules-commonjs": "^7.22.15",
         "babel-eslint": "^10.1.0",
         "css-loader": "^6.8.1",
         "eslint": "^7.32.0",
@@ -532,6 +533,23 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.22.15.tgz",
+      "integrity": "sha512-jWL4eh90w0HQOTKP2MoXXUpVxilxsB2Vl4ji69rSjS3EcZ/v4sBmn+A3NpepuJzBhOaEBbR7udonlHHn5DWidg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-simple-access": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"

--- a/package.json
+++ b/package.json
@@ -13,9 +13,15 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@babel/plugin-transform-modules-commonjs": "^7.22.15",
     "babel-eslint": "^10.1.0",
     "css-loader": "^6.8.1",
+    "eslint": "^7.32.0",
+    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint-plugin-import": "^2.28.1",
+    "hint": "^7.1.10",
     "html-webpack-plugin": "^5.5.3",
+    "jest": "^29.6.3",
     "style-loader": "^3.3.3",
     "stylelint": "^13.13.1",
     "stylelint-config-standard": "^21.0.0",
@@ -23,12 +29,7 @@
     "stylelint-scss": "^3.21.0",
     "webpack": "^5.88.2",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^4.15.1",
-    "eslint": "^7.32.0",
-    "eslint-config-airbnb-base": "^14.2.1",
-    "eslint-plugin-import": "^2.28.1",
-    "hint": "^7.1.10",
-    "jest": "^29.6.3"
+    "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {
     "lodash": "^4.17.21",

--- a/src/modules/getShowsCount.js
+++ b/src/modules/getShowsCount.js
@@ -1,2 +1,12 @@
-const getShowsCount = (shows) => shows.length;
+const getShowsCount = (shows) => {
+  if (!Array.isArray(shows)) {
+    return 0;
+  }
+
+  if (shows === null || shows === undefined) {
+    return 0;
+  }
+  return shows.length;
+};
+
 export default getShowsCount;

--- a/tests/getShowsCount.test.js
+++ b/tests/getShowsCount.test.js
@@ -1,0 +1,45 @@
+import getShowsCount from '../src/modules/getShowsCount.js';
+
+describe('getShowCount', () => {
+  it('returns 0 for an empty array', () => {
+    const shows = [];
+    const result = getShowsCount(shows);
+    expect(result).toBe(0);
+  });
+
+  it('returns 0 for null input', () => {
+    const shows = null;
+    const result = getShowsCount(shows);
+    expect(result).toBe(0);
+  });
+
+  it('returns 0 for undefined input', () => {
+    const shows = undefined;
+    const result = getShowsCount(shows);
+    expect(result).toBe(0);
+  });
+
+  it('returns 0 for non-array object input', () => {
+    const shows = { show1: 'Show 1', show2: 'Show 2' };
+    const result = getShowsCount(shows);
+    expect(result).toBe(0);
+  });
+
+  it('returns the correct count for a non-empty array', () => {
+    const shows = ['Show 1', 'Show 2', 'Show 3'];
+    const result = getShowsCount(shows);
+    expect(result).toBe(3);
+  });
+
+  it('returns the correct count for an array with duplicate items', () => {
+    const shows = ['Show 1', 'Show 1', 'Show 2', 'Show 3'];
+    const result = getShowsCount(shows);
+    expect(result).toBe(4);
+  });
+
+  it('counts an empty string element correctly', () => {
+    const shows = ['Show 1', ''];
+    const result = getShowsCount(shows);
+    expect(result).toBe(2);
+  });
+});


### PR DESCRIPTION
Hello @lucy-sees , please review this PR:

Changes:

Add tests for `getShowsCount` function:
- returns 0 for an empty array
- returns 0 for null input
- returns 0 for undefined input
- returns 0 for non-array object input
- returns the correct count for a non-empty array
- returns the correct count for an array with duplicate items
- counts an empty string element correctly